### PR TITLE
Update tpm2-luks-unlock.sh

### DIFF
--- a/tpm2-luks-unlock.sh
+++ b/tpm2-luks-unlock.sh
@@ -287,7 +287,7 @@ then
    touch \${TMP_FILE}
    tpm2_nvread -s ${KEYSIZE} 0x1500016
 else
-   echo $(tpm2_nvread -s ${KEYSIZE} 0x1500016)
+   echo \$(tpm2_nvread -s ${KEYSIZE} 0x1500016)
 fi
 
 EOF


### PR DESCRIPTION
Script `/usr/local/sbin/tpm2-getkey `should have the line  `echo $(tpm2_nvread -s 64 0x1500016)` instead of `echo /*64 bytes key of passphase*/`